### PR TITLE
feat: 상품 리스트 페이지 UI 및 초기 데이터 구현

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -11,5 +11,5 @@
   "eslint.validate": ["javascript", "typescript"],
   "eslint.nodePath": "./node_modules/eslint",
   "css.lint.unknownAtRules": "ignore",
-  "tailwindCSS.rootFontSize": 10
+  "tailwindCSS.rootFontSize": 16
 }

--- a/next.config.mjs
+++ b/next.config.mjs
@@ -1,4 +1,12 @@
 /** @type {import('next').NextConfig} */
-const nextConfig = {};
+const nextConfig = {
+  images: {
+    remotePatterns: [
+      {
+        hostname: 'cdn.dummyjson.com',
+      },
+    ],
+  },
+};
 
 export default nextConfig;

--- a/package.json
+++ b/package.json
@@ -23,6 +23,7 @@
     "lint": "next lint"
   },
   "dependencies": {
+    "@tailwindcss/line-clamp": "^0.4.4",
     "@tanstack/react-query": "^5.79.0",
     "@tanstack/react-query-devtools": "^5.79.0",
     "clsx": "^2",

--- a/package.json
+++ b/package.json
@@ -28,6 +28,7 @@
     "@tanstack/react-query-devtools": "^5.79.0",
     "clsx": "^2",
     "ky": "^1.8.1",
+    "lucide-react": "^0.511.0",
     "next": "14.2.7",
     "react": "^18",
     "react-dom": "^18",

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -33,7 +33,11 @@ export default function RootLayout({
   return (
     <html lang='ko' className={cn(pretendard.variable)}>
       <body className='font-pretendard'>
-        <Providers>{children}</Providers>
+        <Providers>
+          <main className='mx-auto mb-10 max-w-screen-2xl px-4 lg:px-6'>
+            {children}
+          </main>
+        </Providers>
       </body>
     </html>
   );

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -34,7 +34,7 @@ export default function RootLayout({
     <html lang='ko' className={cn(pretendard.variable)}>
       <body className='font-pretendard'>
         <Providers>
-          <main className='mx-auto mb-10 max-w-screen-2xl px-4 lg:px-6'>
+          <main className='mx-auto mb-10 max-w-screen-xl px-4 lg:px-6'>
             {children}
           </main>
         </Providers>

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,7 +1,0 @@
-import React from 'react';
-
-const page = () => {
-  return <div>Hello World</div>;
-};
-
-export default page;

--- a/src/app/products/_components/ProductList.tsx
+++ b/src/app/products/_components/ProductList.tsx
@@ -3,7 +3,14 @@
 import { getProducts } from '@/lib/api/products';
 import { useQuery } from '@tanstack/react-query';
 import { PRODUCTS_PER_PAGE, PRODUCTS_SELECT } from '../_constants/products';
+import ProductListItem from './ProductListItem';
 
+/**
+ * 상품 목록을 렌더링하는 컴포넌트입니다.
+ *
+ * @TODO infinite scroll 구현 필요
+ * @TODO list, grid로 view 표시 필요
+ */
 const ProductList = () => {
   const { data } = useQuery({
     queryKey: ['products'],
@@ -15,9 +22,15 @@ const ProductList = () => {
       }),
   });
 
-  console.log(data);
+  const listClassName = '[&>*:not(:first-child)]:mt-5'; // 리스트형 클래스네임
 
-  return <div>Products List</div>;
+  return (
+    <section className='mt-[60px]'>
+      {data?.products.map((item) => (
+        <ProductListItem key={item.id} item={item} />
+      ))}
+    </section>
+  );
 };
 
 export default ProductList;

--- a/src/app/products/_components/ProductList.tsx
+++ b/src/app/products/_components/ProductList.tsx
@@ -4,16 +4,26 @@ import { getProducts } from '@/lib/api/products';
 import { useQuery } from '@tanstack/react-query';
 import { PRODUCTS_PER_PAGE, PRODUCTS_SELECT } from '../_constants/products';
 import ProductListItem from './ProductListItem';
+import { cn } from '@/lib/utils/classnames';
 
 /**
  * 상품 목록을 렌더링하는 컴포넌트입니다.
  *
- * @TODO infinite scroll 구현 필요
- * @TODO list, grid로 view 표시 필요
+ * 상품 리스트 데이터를 불러와 리스트 또는 그리드 형태로 렌더링합니다.
+ *
+ * @TODO infinite scroll 기능 구현현
+ * @TODO list, grid로 view 전환 기능 구현 (24시간 유지)
  */
 const ProductList = () => {
   const { data } = useQuery({
-    queryKey: ['products'],
+    queryKey: [
+      'products',
+      {
+        limit: PRODUCTS_PER_PAGE,
+        skip: 0,
+        select: PRODUCTS_SELECT,
+      },
+    ],
     queryFn: () =>
       getProducts({
         limit: PRODUCTS_PER_PAGE,
@@ -23,11 +33,13 @@ const ProductList = () => {
   });
 
   const listClassName = '[&>*:not(:first-child)]:mt-5'; // 리스트형 클래스네임
+  const gridClassName =
+    'grid grid-cols-1 xs:grid-cols-2 gap-4 md:grid-cols-3 lg:grid-cols-4'; // 그리드형 클래스네임
 
   return (
-    <section className='mt-[60px]'>
+    <section className={cn('mt-[60px]', gridClassName)}>
       {data?.products.map((item) => (
-        <ProductListItem key={item.id} item={item} />
+        <ProductListItem key={item.id} item={item} view='grid' />
       ))}
     </section>
   );

--- a/src/app/products/_components/ProductList.tsx
+++ b/src/app/products/_components/ProductList.tsx
@@ -1,0 +1,23 @@
+'use client';
+
+import { getProducts } from '@/lib/api/products';
+import { useQuery } from '@tanstack/react-query';
+import { PRODUCTS_PER_PAGE, PRODUCTS_SELECT } from '../_constants/products';
+
+const ProductList = () => {
+  const { data } = useQuery({
+    queryKey: ['products'],
+    queryFn: () =>
+      getProducts({
+        limit: PRODUCTS_PER_PAGE,
+        skip: 0,
+        select: PRODUCTS_SELECT,
+      }),
+  });
+
+  console.log(data);
+
+  return <div>Products List</div>;
+};
+
+export default ProductList;

--- a/src/app/products/_components/ProductListItem.tsx
+++ b/src/app/products/_components/ProductListItem.tsx
@@ -1,0 +1,46 @@
+import { Product } from '@/types/products.types';
+import { MessageSquare, Star } from 'lucide-react';
+import Image from 'next/image';
+
+interface IProductListItem {
+  item: Product;
+}
+
+/**
+ * 상품 아이템 컴포넌트입니다.
+ *
+ * @param item 상품 아이템 정보
+ */
+const ProductListItem = ({ item }: IProductListItem) => {
+  return (
+    <div key={item.id} className='shadow-custom-shadow rounded-md px-3 py-4'>
+      <div className='flex justify-between gap-6'>
+        <div className='grid flex-1 gap-2 lg:gap-4'>
+          <h2 className='line-clamp-1 text-lg font-bold'>{item.title}</h2>
+          <p className='line-clamp-2 text-sm'>{item.description}</p>
+        </div>
+        <div className='relative aspect-square size-20'>
+          <Image
+            src={item.thumbnail}
+            alt={`${item.title} 이미지`}
+            fill
+            sizes='100%'
+            className='object-cover'
+          />
+        </div>
+      </div>
+      <div className='mt-4 flex items-center gap-3'>
+        <div className='flex items-center gap-1'>
+          <Star size={14} color='#ffbf00' fill='#ffbf00' />
+          <span className='text-xs'>{item.rating}</span>
+        </div>
+        <div className='flex items-center gap-1'>
+          <MessageSquare size={14} color='#94969b' />
+          <span className='text-xs'>{item.reviews.length}</span>
+        </div>
+      </div>
+    </div>
+  );
+};
+
+export default ProductListItem;

--- a/src/app/products/_components/ProductListItem.tsx
+++ b/src/app/products/_components/ProductListItem.tsx
@@ -1,31 +1,49 @@
+import { cn } from '@/lib/utils/classnames';
 import { Product } from '@/types/products.types';
 import { MessageSquare, Star } from 'lucide-react';
 import Image from 'next/image';
 
 interface IProductListItem {
   item: Product;
+  view: 'list' | 'grid';
 }
 
 /**
- * 상품 아이템 컴포넌트입니다.
+ * 개별 상품 아이템을 렌더링하는 컴포넌트입니다.
  *
- * @param item 상품 아이템 정보
+ * 리스트 또는 그리드 형태로 아이템을 다르게 보여줍니다.
+ *
+ * @param item 상품 정보 객체
+ * @param view 상품 아이템 뷰 타입 (list 또는 grid)
  */
-const ProductListItem = ({ item }: IProductListItem) => {
+const ProductListItem = ({ item, view }: IProductListItem) => {
+  const imageContainerClass =
+    view === 'list' ? 'aspect-square size-20' : 'aspect-video w-full';
+  const imageClass = view === 'list' ? 'object-cover' : 'object-contain';
+
   return (
-    <div key={item.id} className='shadow-custom-shadow rounded-md px-3 py-4'>
-      <div className='flex justify-between gap-6'>
+    <div className='shadow-custom-shadow group rounded-md px-3 py-4'>
+      <div
+        className={cn(
+          'flex justify-between gap-6',
+          view === 'grid' && 'flex-col-reverse',
+        )}
+      >
         <div className='grid flex-1 gap-2 lg:gap-4'>
           <h2 className='line-clamp-1 text-lg font-bold'>{item.title}</h2>
           <p className='line-clamp-2 text-sm'>{item.description}</p>
         </div>
-        <div className='relative aspect-square size-20'>
+        <div className={cn('relative', imageContainerClass)}>
           <Image
             src={item.thumbnail}
-            alt={`${item.title} 이미지`}
+            alt={`${item.title} 상품 썸네일`}
             fill
+            priority
             sizes='100%'
-            className='object-cover'
+            className={cn(
+              'transition-transform duration-300 ease-in-out will-change-transform group-hover:scale-110',
+              imageClass,
+            )}
           />
         </div>
       </div>

--- a/src/app/products/_constants/products.ts
+++ b/src/app/products/_constants/products.ts
@@ -1,0 +1,4 @@
+export const PRODUCTS_PER_PAGE = 20;
+
+export const PRODUCTS_SELECT =
+  'title,description,thumbnail,rating,reviews,category';

--- a/src/app/products/page.tsx
+++ b/src/app/products/page.tsx
@@ -1,5 +1,30 @@
-const ProductsPage = () => {
-  return <div>Products Page</div>;
+import { getProducts } from '@/lib/api/products';
+import {
+  dehydrate,
+  HydrationBoundary,
+  QueryClient,
+} from '@tanstack/react-query';
+import ProductList from './_components/ProductList';
+import { PRODUCTS_PER_PAGE, PRODUCTS_SELECT } from './_constants/products';
+
+const ProductsPage = async () => {
+  const queryClient = new QueryClient();
+
+  await queryClient.prefetchQuery({
+    queryKey: ['products'],
+    queryFn: () =>
+      getProducts({
+        limit: PRODUCTS_PER_PAGE,
+        skip: 0,
+        select: PRODUCTS_SELECT,
+      }),
+  });
+
+  return (
+    <HydrationBoundary state={dehydrate(queryClient)}>
+      <ProductList />
+    </HydrationBoundary>
+  );
 };
 
 export default ProductsPage;

--- a/src/app/products/page.tsx
+++ b/src/app/products/page.tsx
@@ -1,0 +1,5 @@
+const ProductsPage = () => {
+  return <div>Products Page</div>;
+};
+
+export default ProductsPage;

--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -1,0 +1,11 @@
+import { NextResponse } from 'next/server';
+import type { NextRequest } from 'next/server';
+
+// /에 접근 시 /products로 리다이렉트
+export function middleware(request: NextRequest) {
+  return NextResponse.redirect(new URL('/products', request.url));
+}
+
+export const config = {
+  matcher: '/',
+};

--- a/src/types/products.types.ts
+++ b/src/types/products.types.ts
@@ -1,6 +1,8 @@
 // 상품 리스트 조회 파라미터
 export interface ProductsParams {
   limit?: number;
+  skip?: number;
+  select?: string;
 }
 
 // 상품 리스트 조회 응답
@@ -16,24 +18,9 @@ export interface Product {
   title: string;
   description: string;
   category: string;
-  price: number;
-  discountPercentage: number;
   rating: number;
-  stock: number;
-  tags: string[];
-  brand: string;
-  sku: string;
-  weight: number;
-  dimensions: Dimensions;
-  warrantyInformation: string;
-  shippingInformation: string;
-  availabilityStatus: string;
   reviews: Review[];
-  returnPolicy: string;
-  minimumOrderQuantity: number;
-  meta: ProductMeta;
   thumbnail: string;
-  images: string[];
 }
 
 export interface Dimensions {

--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -17,8 +17,14 @@ const config: Config = {
       fontFamily: {
         pretendard: ['var(--font-pretendard)', ...defaultTheme.fontFamily.sans],
       },
+      boxShadow: {
+        'custom-shadow': '0px 4px 20px 0px #00000014',
+      },
+      screens: {
+        '2xl': '1440px',
+      },
     },
   },
-  plugins: [tailwindcssAnimate],
+  plugins: [tailwindcssAnimate, require('@tailwindcss/line-clamp')],
 };
 export default config;

--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -21,7 +21,7 @@ const config: Config = {
         'custom-shadow': '0px 4px 20px 0px #00000014',
       },
       screens: {
-        '2xl': '1440px',
+        xs: '480px',
       },
     },
   },

--- a/yarn.lock
+++ b/yarn.lock
@@ -263,6 +263,11 @@
     "@swc/counter" "^0.1.3"
     tslib "^2.4.0"
 
+"@tailwindcss/line-clamp@^0.4.4":
+  version "0.4.4"
+  resolved "https://registry.yarnpkg.com/@tailwindcss/line-clamp/-/line-clamp-0.4.4.tgz#767cf8e5d528a5d90c9740ca66eb079f5e87d423"
+  integrity sha512-5U6SY5z8N42VtrCrKlsTAA35gy2VSyYtHWCsg1H87NU1SXnEfekTVlrga9fzUDrrHcGi2Lb5KenUWb4lRQT5/g==
+
 "@tanstack/query-core@5.79.0":
   version "5.79.0"
   resolved "https://registry.yarnpkg.com/@tanstack/query-core/-/query-core-5.79.0.tgz#947e13c409555a8ca0a17abdf3dff9eb77af45e6"

--- a/yarn.lock
+++ b/yarn.lock
@@ -2242,6 +2242,11 @@ lru-cache@^10.2.0:
   resolved "https://registry.yarnpkg.com/lru-cache/-/lru-cache-10.4.3.tgz#410fc8a17b70e598013df257c2446b7f3383f119"
   integrity sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ==
 
+lucide-react@^0.511.0:
+  version "0.511.0"
+  resolved "https://registry.yarnpkg.com/lucide-react/-/lucide-react-0.511.0.tgz#1dfef3065c725ac83f5fe0a6f02d1e0b0c36e641"
+  integrity sha512-VK5a2ydJ7xm8GvBeKLS9mu1pVK6ucef9780JVUjw6bAjJL/QXnd4Y0p7SPeOUMC27YhzNCZvm5d/QX0Tp3rc0w==
+
 math-intrinsics@^1.1.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/math-intrinsics/-/math-intrinsics-1.1.0.tgz#a0dd74be81e2aa5c2f27e65ce283605ee4e2b7f9"


### PR DESCRIPTION
## 📝 작업 내역

- '/' 경로 접근 시 '/products'로 리다이렉트되는 미들웨어 추가
- 상품 리스트 초기 데이터 prefetch 적용
- 'next/image' 외부 도메인 허용 설정
- layout 최대 너비, 가운데 정렬 적용
- 상품 리스트 퍼블리싱 (grid, list 뷰)

## TODO
- 상품 리스트 무한 스크롤 기능 추가
- 뷰 타입 24시간 단위로 전환 기능 추가 
